### PR TITLE
Adjust HandlerErrorCode mapping type for SDK ConflictException

### DIFF
--- a/aws-ses-mailmanageringresspoint/src/main/java/software/amazon/ses/mailmanageringresspoint/BaseHandlerStd.java
+++ b/aws-ses-mailmanageringresspoint/src/main/java/software/amazon/ses/mailmanageringresspoint/BaseHandlerStd.java
@@ -31,7 +31,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   private final Map<Class<? extends Exception>, HandlerErrorCode> exceptionMap = Map.of(
           IllegalArgumentException.class, HandlerErrorCode.InvalidRequest,
           ValidationException.class, HandlerErrorCode.InvalidRequest,
-          ConflictException.class, HandlerErrorCode.AlreadyExists,
+          ConflictException.class, HandlerErrorCode.ResourceConflict,
           ResourceNotFoundException.class, HandlerErrorCode.NotFound,
           ServiceQuotaExceededException.class, HandlerErrorCode.ServiceLimitExceeded,
           AwsServiceException.class, HandlerErrorCode.GeneralServiceException

--- a/aws-ses-mailmanageringresspoint/src/test/java/software/amazon/ses/mailmanageringresspoint/CreateHandlerTest.java
+++ b/aws-ses-mailmanageringresspoint/src/test/java/software/amazon/ses/mailmanageringresspoint/CreateHandlerTest.java
@@ -181,7 +181,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).isEqualTo("IngressPoint already exists");
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ResourceConflict);
     }
 
     @Test

--- a/aws-ses-mailmanagerrelay/src/main/java/software/amazon/ses/mailmanagerrelay/BaseHandlerStd.java
+++ b/aws-ses-mailmanagerrelay/src/main/java/software/amazon/ses/mailmanagerrelay/BaseHandlerStd.java
@@ -22,7 +22,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private final Map<Class<? extends Exception>, HandlerErrorCode> exceptionMap = Map.of(
             IllegalArgumentException.class, HandlerErrorCode.InvalidRequest,
             ValidationException.class, HandlerErrorCode.InvalidRequest,
-            ConflictException.class, HandlerErrorCode.AlreadyExists,
+            ConflictException.class, HandlerErrorCode.ResourceConflict,
             ResourceNotFoundException.class, HandlerErrorCode.NotFound,
             ServiceQuotaExceededException.class, HandlerErrorCode.ServiceLimitExceeded,
             AwsServiceException.class, HandlerErrorCode.GeneralServiceException

--- a/aws-ses-mailmanagerrelay/src/test/java/software/amazon/ses/mailmanagerrelay/CreateHandlerTest.java
+++ b/aws-ses-mailmanagerrelay/src/test/java/software/amazon/ses/mailmanagerrelay/CreateHandlerTest.java
@@ -159,6 +159,6 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isEqualTo("Conflict exception is thrown here");
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ResourceConflict);
     }
 }

--- a/aws-ses-mailmanagerruleset/src/main/java/software/amazon/ses/mailmanagerruleset/BaseHandlerStd.java
+++ b/aws-ses-mailmanagerruleset/src/main/java/software/amazon/ses/mailmanagerruleset/BaseHandlerStd.java
@@ -20,7 +20,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   private final Map<Class<? extends Exception>, HandlerErrorCode> exceptionMap = Map.of(
           IllegalArgumentException.class, HandlerErrorCode.InvalidRequest,
           ValidationException.class, HandlerErrorCode.InvalidRequest,
-          ConflictException.class, HandlerErrorCode.AlreadyExists,
+          ConflictException.class, HandlerErrorCode.ResourceConflict,
           ResourceNotFoundException.class, HandlerErrorCode.NotFound,
           ServiceQuotaExceededException.class, HandlerErrorCode.ServiceLimitExceeded,
           AwsServiceException.class, HandlerErrorCode.GeneralServiceException

--- a/aws-ses-mailmanagerruleset/src/test/java/software/amazon/ses/mailmanagerruleset/CreateHandlerTest.java
+++ b/aws-ses-mailmanagerruleset/src/test/java/software/amazon/ses/mailmanagerruleset/CreateHandlerTest.java
@@ -143,13 +143,14 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .clientRequestToken(CLIENT_REQUEST_TOKEN)
                 .build();
 
-        when(mailManagerClient.createRuleSet(any(CreateRuleSetRequest.class))).thenThrow(ConflictException.builder().build());
+        when(mailManagerClient.createRuleSet(any(CreateRuleSetRequest.class))).thenThrow(ConflictException.builder().message("RuleSet already exists").build());
 
         final ProgressEvent<ResourceModel, CallbackContext> response = handler.handleRequest(proxy, request, new CallbackContext(), proxyClient, logger);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ResourceConflict);
+        assertThat(response.getMessage()).isEqualTo("RuleSet already exists");
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModels()).isNull();
     }

--- a/aws-ses-mailmanagertrafficpolicy/src/main/java/software/amazon/ses/mailmanagertrafficpolicy/BaseHandlerStd.java
+++ b/aws-ses-mailmanagertrafficpolicy/src/main/java/software/amazon/ses/mailmanagertrafficpolicy/BaseHandlerStd.java
@@ -21,7 +21,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
   private final Map<Class<? extends Exception>, HandlerErrorCode> exceptionMap = Map.of(
           IllegalArgumentException.class, HandlerErrorCode.InvalidRequest,
           ValidationException.class, HandlerErrorCode.InvalidRequest,
-          ConflictException.class, HandlerErrorCode.AlreadyExists,
+          ConflictException.class, HandlerErrorCode.ResourceConflict,
           ResourceNotFoundException.class, HandlerErrorCode.NotFound,
           ServiceQuotaExceededException.class, HandlerErrorCode.ServiceLimitExceeded,
           AwsServiceException.class, HandlerErrorCode.GeneralServiceException

--- a/aws-ses-mailmanagertrafficpolicy/src/test/java/software/amazon/ses/mailmanagertrafficpolicy/CreateHandlerTest.java
+++ b/aws-ses-mailmanagertrafficpolicy/src/test/java/software/amazon/ses/mailmanagertrafficpolicy/CreateHandlerTest.java
@@ -158,7 +158,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getMessage()).isEqualTo("TrafficPolicy already exists");
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ResourceConflict);
     }
 
     @Test


### PR DESCRIPTION
### Notes

Adjust the `HandlerErrorCode` mapping type for the SDK `ConflictException` to handle the following scenarios:

- The resource has been created and cannot be recreated again.
- The resource is to be deleted but is being used by other resources as a dependency.